### PR TITLE
Add articles table migration, model, and status enum

### DIFF
--- a/app/Enums/ArticleStatus.php
+++ b/app/Enums/ArticleStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum ArticleStatus: string
+{
+    case Published = 'published';
+    case Draft = 'draft';
+}

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ArticleStatus;
+use Illuminate\Database\Eloquent\Model;
+
+class Article extends Model
+{
+    protected $fillable = ['title', 'slug', 'content', 'status'];
+    protected $casts = [
+        'status' => ArticleStatus::class,
+    ];
+}

--- a/database/migrations/2025_09_28_122644_create_articles_table.php
+++ b/database/migrations/2025_09_28_122644_create_articles_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Enums\ArticleStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->text('content');
+            $table->string('status')->default(ArticleStatus::Published->value)->nullable();
+            $table->dateTime('published_at')->nullable();;
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('articles');
+    }
+};


### PR DESCRIPTION
- Created `articles` table with fields like title, slug, content, status, and published_at.
- Added `Article` model with fillable fields and status casting.
- Defined `ArticleStatus` enum with draft and published values.