### PR TITLE
Add Filament resources for `Article` management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_TIMEZONE=UTC
-APP_URL=http://localhost
+APP_URL=http://localhost:8000
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/README.md
+++ b/README.md
@@ -63,11 +63,17 @@ In a **separate terminal**, build the assets in watch mode:
 npm run dev
 ```
 
+Create a admin user for the Filament admin panel:
+
+```bash
+php artisan make:filament-user
+```
 Finally, start the development server:
 
 ```bash
 php artisan serve
 ```
+> You can now access the application at [http://localhost:8000](http://localhost:8000) and the admin panel at [http://localhost:8000/admin](http://localhost:8000/admin).
 
 > Note: By default, emails are sent to the `log` driver. You can change this in the `.env` file to something like `mailtrap`.
 

--- a/app/Filament/Resources/Articles/ArticleResource.php
+++ b/app/Filament/Resources/Articles/ArticleResource.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Filament\Resources\Articles;
+
+use App\Filament\Resources\Articles\Pages\CreateArticle;
+use App\Filament\Resources\Articles\Pages\EditArticle;
+use App\Filament\Resources\Articles\Pages\ListArticles;
+use App\Filament\Resources\Articles\Pages\ViewArticle;
+use App\Filament\Resources\Articles\Schemas\ArticleForm;
+use App\Filament\Resources\Articles\Schemas\ArticleInfolist;
+use App\Filament\Resources\Articles\Tables\ArticlesTable;
+use App\Models\Article;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class ArticleResource extends Resource
+{
+    protected static ?string $model = Article::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    public static function form(Schema $schema): Schema
+    {
+        return ArticleForm::configure($schema);
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return ArticleInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return ArticlesTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListArticles::route('/'),
+            'create' => CreateArticle::route('/create'),
+            'view' => ViewArticle::route('/{record}'),
+            'edit' => EditArticle::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Articles/Pages/CreateArticle.php
+++ b/app/Filament/Resources/Articles/Pages/CreateArticle.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Articles\Pages;
+
+use App\Filament\Resources\Articles\ArticleResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateArticle extends CreateRecord
+{
+    protected static string $resource = ArticleResource::class;
+}

--- a/app/Filament/Resources/Articles/Pages/EditArticle.php
+++ b/app/Filament/Resources/Articles/Pages/EditArticle.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Filament\Resources\Articles\Pages;
+
+use App\Enums\ArticleStatus;
+use App\Filament\Resources\Articles\ArticleResource;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\ViewAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditArticle extends EditRecord
+{
+    protected static string $resource = ArticleResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ViewAction::make(),
+            DeleteAction::make(),
+        ];
+    }
+
+}

--- a/app/Filament/Resources/Articles/Pages/ListArticles.php
+++ b/app/Filament/Resources/Articles/Pages/ListArticles.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\Articles\Pages;
+
+use App\Filament\Resources\Articles\ArticleResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListArticles extends ListRecords
+{
+    protected static string $resource = ArticleResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Articles/Pages/ViewArticle.php
+++ b/app/Filament/Resources/Articles/Pages/ViewArticle.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Filament\Resources\Articles\Pages;
+
+use App\Filament\Resources\Articles\ArticleResource;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewArticle extends ViewRecord
+{
+    protected static string $resource = ArticleResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            EditAction::make(),
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Articles/Schemas/ArticleForm.php
+++ b/app/Filament/Resources/Articles/Schemas/ArticleForm.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Filament\Resources\Articles\Schemas;
+
+use App\Enums\ArticleStatus;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\MarkdownEditor;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Textarea;
+use Filament\Schemas\Schema;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Illuminate\Support\Str;
+
+class ArticleForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('title')
+                    ->live(onBlur: true)
+                    ->afterStateUpdated(function (Get $get, Set $set, ?string $old, ?string $state) {
+                        if (($get('slug') ?? '') !== Str::slug($old)) {
+                            return;
+                        }
+                        $set('slug', Str::slug($state));
+                    })
+                    ->required(),
+                TextInput::make('slug')
+                    ->scopedUnique()
+                    ->required(),
+                MarkdownEditor::make('content')
+                    ->fileAttachmentsDirectory('articles')
+                    ->fileAttachmentsDisk('public')
+                    ->required()
+                    ->columnSpanFull(),
+                Select::make('status')
+                    ->options(ArticleStatus::class)
+                    ->default(ArticleStatus::Published)
+                    ->required(),
+//                DateTimePicker::make('published_at')
+//                    ->nullable()
+//                    ->after('status'),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Articles/Schemas/ArticleInfolist.php
+++ b/app/Filament/Resources/Articles/Schemas/ArticleInfolist.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Filament\Resources\Articles\Schemas;
+
+use App\Enums\ArticleStatus;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Support\Enums\FontWeight;
+use Filament\Schemas\Schema;;
+
+class ArticleInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Grid::make()
+                    ->columns(1)
+                    ->schema([
+                        Section::make('Main Information')
+                            ->description('Item details')
+                            ->icon('heroicon-o-document-text')
+                            ->schema([
+                                Grid::make(2)
+                                    ->schema([
+                                        TextEntry::make('title')
+                                            ->size('large')
+                                            ->weight(FontWeight::Bold)
+                                            ->color('primary')
+                                            ->icon('heroicon-m-pencil-square')
+                                            ->columnSpanFull(),
+
+                                        TextEntry::make('slug')
+                                            ->label('URL')
+                                            ->icon('heroicon-m-link')
+                                            ->copyable()
+                                            ->copyMessage('Slug copié!')
+                                            ->copyMessageDuration(1500)
+                                            ->badge()
+                                            ->color('gray'),
+
+                                        TextEntry::make('status')
+                                            ->badge()
+                                            ->icon('heroicon-m-flag')
+                                            ->color(
+                                                fn ($state) => match ($state) {
+                                                    ArticleStatus::Draft => 'danger',
+                                                    ArticleStatus::Published => 'primary',
+                                                    default => 'success',
+                                                }
+                                            )
+                                    ]),
+                            ])
+                            ->collapsible(),
+                        Section::make('Metadata')
+                            ->description('Date and System Information')
+                            ->icon('heroicon-o-clock')
+                            ->schema([
+                                Grid::make(3)
+                                    ->schema([
+                                        TextEntry::make('published_at')
+                                            ->label('Publication date')
+                                            ->dateTime('d/m/Y à H:i')
+                                            ->icon('heroicon-m-calendar')
+                                            ->color('success')
+                                            ->placeholder('Unpublished'),
+
+                                        TextEntry::make('created_at')
+                                            ->label('Created on')
+                                            ->dateTime('d/m/Y à H:i')
+                                            ->icon('heroicon-m-plus-circle')
+                                            ->color('info'),
+
+                                        TextEntry::make('updated_at')
+                                            ->label('Modified on')
+                                            ->dateTime('d/m/Y à H:i')
+                                            ->icon('heroicon-m-arrow-path')
+                                            ->color('warning')
+                                            ->since(),
+                                    ]),
+                            ])
+                            ->collapsible()
+                            ->collapsed(true),
+                    ]),
+
+                Section::make('Content')
+                    ->description('Article body')
+                    ->icon('heroicon-o-document')
+                    ->schema([
+                        TextEntry::make('content')
+                            ->label('Full text')
+                            ->markdown()
+                            ->prose()
+                            ->columnSpanFull()
+                            ->extraAttributes([
+                                'class' => 'prose prose-sm max-w-none dark:prose-invert',
+                                'style' => 'max-height: 500px; overflow-y: auto; padding: 1rem; border-radius: 0.5rem;'
+                            ]),
+                    ])
+                    ->collapsible()
+                    ->collapsed(false),
+
+            ]);
+    }
+}

--- a/app/Filament/Resources/Articles/Tables/ArticlesTable.php
+++ b/app/Filament/Resources/Articles/Tables/ArticlesTable.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Filament\Resources\Articles\Tables;
+
+use App\Enums\ArticleStatus;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\ViewAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class ArticlesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('title')
+                    ->searchable(),
+                TextColumn::make('slug')
+                    ->searchable(),
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(
+                        fn ($state) => match ($state) {
+                            ArticleStatus::Draft => 'danger',
+                            ArticleStatus::Published => 'primary',
+                            default => 'success',
+                        }
+                    )
+                    ->searchable(),
+                TextColumn::make('published_at')
+                    ->placeholder('Unpublished')
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->recordActions([
+                ViewAction::make(),
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -3,8 +3,11 @@
 namespace App\Models;
 
 use App\Enums\ArticleStatus;
+use App\Observers\ArticleObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Model;
 
+#[ObservedBy([ArticleObserver::class])]
 class Article extends Model
 {
     protected $fillable = ['title', 'slug', 'content', 'status', 'published_at'];

--- a/app/Observers/ArticleObserver.php
+++ b/app/Observers/ArticleObserver.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Observers;
+
+use App\Enums\ArticleStatus;
+use App\Models\Article;
+
+class ArticleObserver
+{
+
+    public function saving(Article $article): void
+    {
+        if ($article->status === ArticleStatus::Published && is_null($article->published_at)) {
+            $article->published_at = now();
+        }
+    }
+}


### PR DESCRIPTION
- Created `ArticleResource` with pages for listing, creating, editing, and viewing articles.
- Added forms and infolists for displaying and managing article data.
- Set up `ArticlesTable` with searchable and sortable columns.
- Registered `ArticleObserver` to automate the setting of `published_at` when status is updated to published.
- Updated `Article` model to support this observer and added admin panel setup instructions in `README.md`.
<img width="1763" height="826" alt="image" src="https://github.com/user-attachments/assets/ccef3f53-3484-4df2-ac03-c7c1b3390684" />
<img width="1763" height="1015" alt="image" src="https://github.com/user-attachments/assets/e9c6264b-ebd1-4a03-8508-16f537e256d5" />
<img width="1763" height="863" alt="image" src="https://github.com/user-attachments/assets/6ab7697f-b3f3-41eb-b59a-8ddec7d353cf" />
