### PR TITLE
Update PHP version in CI workflows to 8.4

### DIFF
--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3' # Update according to your Laravel version
+          php-version: '8.4'
 
       - name: Prepare Laravel
         run: cp .env.example .env

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
           coverage: none
 


### PR DESCRIPTION
- Changed the PHP version from 8.3 to 8.4 in `.github/workflows/pest.yml`.
- Updated the PHP version from 8.2 to 8.4 in `.github/workflows/pint.yml`.