### PR TITLE
feat: Ajout de l'intégration du profil LinkedIn pour les auteurs de projets

### DIFF
--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -21,6 +21,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
             'photo' => ['nullable', 'mimes:jpg,jpeg,png', 'max:1024'],
+            'linkedin_url' => ['nullable', 'url', 'max:255'],
         ])->validateWithBag('updateProfileInformation');
 
         if (isset($input['photo'])) {
@@ -34,6 +35,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             $user->forceFill([
                 'name' => $input['name'],
                 'email' => $input['email'],
+                'linkedin_url' => $input['linkedin_url'] ?? null,
             ])->save();
         }
     }
@@ -49,6 +51,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             'name' => $input['name'],
             'email' => $input['email'],
             'email_verified_at' => null,
+            'linkedin_url' => $input['linkedin_url'] ?? null,
         ])->save();
 
         $user->sendEmailVerificationNotification();

--- a/app/Http/Livewire/UpdateProfileInformationForm.php
+++ b/app/Http/Livewire/UpdateProfileInformationForm.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+
+class UpdateProfileInformationForm extends Component
+{
+    use WithFileUploads;
+
+    /**
+     * The component's state.
+     *
+     * @var array
+     */
+    public $state = [];
+
+    /**
+     * The new avatar for the user.
+     *
+     * @var mixed
+     */
+    public $photo;
+
+    /**
+     * Determine if the verification email was sent.
+     *
+     * @var bool
+     */
+    public $verificationLinkSent = false;
+
+    /**
+     * Prepare the component.
+     *
+     * @return void
+     */
+    public function mount()
+    {
+        $user = Auth::user();
+
+        $this->state = array_merge([
+            'email' => $user->email,
+            'linkedin_url' => $user->linkedin_url,
+        ], $user->withoutRelations()->toArray());
+    }
+
+    /**
+     * Update the user's profile information.
+     *
+     * @param  \Laravel\Fortify\Contracts\UpdatesUserProfileInformation  $updater
+     * @return \Illuminate\Http\RedirectResponse|null
+     */
+    public function updateProfileInformation(UpdatesUserProfileInformation $updater)
+    {
+        $this->resetErrorBag();
+
+        $updater->update(
+            Auth::user(),
+            $this->photo
+                ? array_merge($this->state, ['photo' => $this->photo])
+                : $this->state
+        );
+
+        if (isset($this->photo)) {
+            return redirect()->route('profile.show');
+        }
+
+        $this->dispatch('saved');
+
+        $this->dispatch('refresh-navigation-menu');
+    }
+
+    /**
+     * Delete user's profile photo.
+     *
+     * @return void
+     */
+    public function deleteProfilePhoto()
+    {
+        Auth::user()->deleteProfilePhoto();
+
+        $this->dispatch('refresh-navigation-menu');
+    }
+
+    /**
+     * Sent the email verification.
+     *
+     * @return void
+     */
+    public function sendEmailVerification()
+    {
+        Auth::user()->sendEmailVerificationNotification();
+
+        $this->verificationLinkSent = true;
+    }
+
+    /**
+     * Get the current user of the application.
+     *
+     * @return mixed
+     */
+    public function getUserProperty()
+    {
+        return Auth::user();
+    }
+
+    /**
+     * Render the component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('profile.update-profile-information-form');
+    }
+}

--- a/app/Livewire/Pages/ProjectPage.php
+++ b/app/Livewire/Pages/ProjectPage.php
@@ -50,6 +50,7 @@ class ProjectPage extends Component
             ->where('status', ProjectStatus::Approved)
             ->with('categories')
             ->with('technologies')
+            ->with('user')
             ->withCount('votes')
             ->when($this->search, function ($query) {
                 $query->where(function ($q) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -41,6 +41,7 @@ class User extends Authenticatable implements FilamentUser
         'provider_token',
         'email_verified_at',
         'role',
+        'linkedin_url',
     ];
 
     /**

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -3,8 +3,10 @@
 namespace App\Providers;
 
 use App\Actions\Jetstream\DeleteUser;
+use App\Http\Livewire\UpdateProfileInformationForm;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Jetstream\Jetstream;
+use Livewire\Livewire;
 
 class JetstreamServiceProvider extends ServiceProvider
 {
@@ -24,6 +26,9 @@ class JetstreamServiceProvider extends ServiceProvider
         $this->configurePermissions();
 
         Jetstream::deleteUsersUsing(DeleteUser::class);
+
+        // Register custom Livewire component for profile form
+        Livewire::component('profile.update-profile-information-form', UpdateProfileInformationForm::class);
     }
 
     /**

--- a/database/migrations/2025_11_04_163837_add_linkedin_url_to_users_table.php
+++ b/database/migrations/2025_11_04_163837_add_linkedin_url_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('linkedin_url')->nullable()->after('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('linkedin_url');
+        });
+    }
+};

--- a/resources/views/livewire/pages/project-page.blade.php
+++ b/resources/views/livewire/pages/project-page.blade.php
@@ -113,7 +113,13 @@
                                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-1">
                                             <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
                                         </svg>
-                                        <span>{{ $project->user->name }}</span>
+                                        @if($project->user->linkedin_url)
+                                            <a href="{{ $project->user->linkedin_url }}" target="_blank" rel="noopener noreferrer" class="text-red-600 hover:text-red-700 hover:underline font-medium">
+                                                {{ $project->user->name }}
+                                            </a>
+                                        @else
+                                            <span>{{ $project->user->name }}</span>
+                                        @endif
                                     </div>
                                 </div>
 

--- a/resources/views/profile/update-profile-information-form.blade.php
+++ b/resources/views/profile/update-profile-information-form.blade.php
@@ -81,6 +81,13 @@
                 @endif
             @endif
         </div>
+
+        <!-- LinkedIn URL -->
+        <div class="col-span-6 sm:col-span-4">
+            <x-label for="linkedin_url" value="{{ __('LinkedIn Profile URL') }}" />
+            <x-input id="linkedin_url" type="url" class="mt-1 block w-full" wire:model="state.linkedin_url" autocomplete="off" placeholder="https://www.linkedin.com/in/your-profile" />
+            <x-input-error for="linkedin_url" class="mt-2" />
+        </div>
     </x-slot>
 
     <x-slot name="actions">


### PR DESCRIPTION
## Résumé
Cette PR ajoute l'intégration du profil LinkedIn, permettant aux utilisateurs de lier leur profil LinkedIn et de l'afficher sur les pages de projets. Lors de la consultation de la liste des projets, si un utilisateur a ajouté son URL LinkedIn, son nom devient un lien cliquable qui redirige vers son profil.

## Modifications apportées

### Base de données
- Ajout de la colonne `linkedin_url` à la table `users` (nullable, max 255 caractères)
- Création de la migration: `2025_11_04_163837_add_linkedin_url_to_users_table.php`

### Backend
- Mise à jour du modèle `User` pour inclure `linkedin_url` dans les attributs fillable
- Modification de l'action `UpdateUserProfileInformation` pour valider et enregistrer l'URL LinkedIn
- Création d'un composant Livewire `UpdateProfileInformationForm` personnalisé pour initialiser correctement l'URL LinkedIn dans l'état du composant
- Enregistrement du composant Livewire personnalisé dans `JetstreamServiceProvider`
- Mise à jour du composant `ProjectPage` pour charger la relation `user` en eager loading avec les projets

### Frontend
- Ajout du champ de saisie URL LinkedIn au formulaire de mise à jour du profil (`resources/views/profile/update-profile-information-form.blade.php`)
- Mise à jour de l'affichage des projets pour afficher le nom de l'auteur cliquable lorsque l'URL LinkedIn existe (`resources/views/livewire/pages/project-page.blade.php`)
- Style des liens LinkedIn avec la couleur rouge pour correspondre au branding du site

## Comment tester
1. Accéder aux paramètres de votre profil utilisateur
2. Ajouter votre URL de profil LinkedIn dans le nouveau champ "LinkedIn Profile URL"
3. Enregistrer les modifications de votre profil
4. Soumettre un projet (ou consulter l'un de vos projets existants)
5. Sur la page de liste des projets, votre nom devrait maintenant être cliquable et rediriger vers votre profil LinkedIn
6. Les utilisateurs sans URL LinkedIn verront toujours leur nom affiché normalement (non cliquable)

## Notes
- L'URL LinkedIn est optionnelle (champ nullable)
- Validation de l'URL pour garantir le bon format
- Rétrocompatible - les utilisateurs existants sans URL LinkedIn ne sont pas affectés
- Performance optimisée avec le chargement eager loading des relations utilisateur