### PR TITLE
Wrapped icons in their own div, centered with flex

### DIFF
--- a/resources/views/components/topbar-guest.blade.php
+++ b/resources/views/components/topbar-guest.blade.php
@@ -36,7 +36,7 @@
                         <form method="POST" action="{{ route('logout') }}" class="flex items-center">
                             @csrf
                             <button type="submit"
-                                class="inline-flex items-center justify-center rounded-lg px-3 py-2 leading-none text-gray-900 hover:text-red-600 transition-colors bg-transparent border-0 cursor-pointer"
+                                class="inline-flex items-center justify-center rounded-lg p-0 leading-none text-gray-900 hover:text-red-600 transition-colors bg-transparent border-0 cursor-pointer"
                                 title="{{ __('Logout') }}" aria-label="{{ __('Logout') }}">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5 text-red-600">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15m-3 0-3-3m0 0 3-3m-3 3H15" />


### PR DESCRIPTION
I wrapped the GitHub link, language selector, and login/logout in a single div with flex items-center gap-3.
Normalized the clickable areas to match the language button by using inline-flex items-center justify-center rounded-lg px-3 py-2 leading-none and set all SVGs to h-5 w-5.
Added items-center to the parent nav so the row vertically centers across sizes.
This will align the three icons consistently without changing the Livewire component.